### PR TITLE
Fix windows-specific issues

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -99,6 +99,7 @@ extern "C" {
     #[doc = " @param[out] retval a ModelState pointer"]
     #[doc = ""]
     #[doc = " @return Zero on success, non-zero on failure."]
+    #[cfg(not(target_os = "windows"))]
     pub fn STT_CreateModelFromBuffer(
         aModelBuffer: *const ::std::os::raw::c_char,
         aBufferSize: ::std::os::raw::c_uint,
@@ -154,6 +155,7 @@ extern "C" {
     #[doc = " @param aBufferSize Size of scorer buffer."]
     #[doc = ""]
     #[doc = " @return Zero on success, non-zero on failure (invalid arguments)."]
+    #[cfg(not(target_os = "windows"))]
     pub fn STT_EnableExternalScorerFromBuffer(
         aCtx: *mut ModelState,
         aScorerBuffer: *const ::std::os::raw::c_char,

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -78,7 +78,8 @@ pub const STT_Error_Codes_STT_ERR_FAIL_CLEAR_HOTWORD: STT_Error_Codes = 12297;
 pub const STT_Error_Codes_STT_ERR_FAIL_ERASE_HOTWORD: STT_Error_Codes = 12304;
 pub type STT_Error_Codes = ::std::os::raw::c_uint;
 
-#[link(name = "stt")]
+#[cfg_attr(not(target_os = "windows"), link(name = "stt"))]
+#[cfg_attr(target_os = "windows", link(name = "libstt.so.if"))]
 extern "C" {
     #[doc = " @brief An object providing an interface to a trained Coqui STT model."]
     #[doc = ""]


### PR DESCRIPTION
This PR solves [this issue](https://github.com/tazz4843/coqui-stt/issues/3) for good. To do that, the link attribute has been split into two platform-specific ones that link to the needed libraries for each OS.

This PR, alongside [this one in coqui-stt](https://github.com/tazz4843/coqui-stt/pull/8) also fixes some other problems derived from the API differences between linux and windows. Specifically, `FromBuffer` bindings are not present in the windows libraries, and if the developer tries to call them, the program will panic.
